### PR TITLE
feat: alias dynamic key event if key is a space

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Set `pauseOnInput` to prevent the utility from capturing keydown events on input
 
 ## Examples
 
-### Escape to Close Modal
+### Escape to close a modal
 
 In this use case, keydown events are paused if the modal is not open.
 
@@ -131,12 +131,11 @@ Use the `combo` dispatched event to listen for a combination of keys.
 
 Example:
 
-<!-- prettier-ignore-start -->
-```html
+```svelte no-eval
 <Keydown on:Enter />
 <Keydown on:Escape />
+<Keydown on:Space />
 ```
-<!-- prettier-ignore-end -->
 
 #### `on:key`
 

--- a/src/Keydown.svelte
+++ b/src/Keydown.svelte
@@ -42,7 +42,7 @@
         dispatch("combo", combination);
       }
 
-      dispatch(key);
+      dispatch(key === " " ? "Space" : key);
       dispatch("key", key);
     }
   }} />


### PR DESCRIPTION
Closes #9

Currently, it's not possible to listen to the dispatched `Key` event for a space character (" ").

This PR aliases the " " character to "Space" for the dynamic key event.

`on:key={e => e.detail}` remains the same.

```svelte
<Keydown on:Space />
```