### PR TITLE
Forward `keyup`, `keydown` events to allow user to prevent default behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can use `on:keydown` to prevent the default behavior for certain keys.
 
 In the following example, pressing "Space" should not cause the browser page to scroll.
 
-```svelte no-display
+```svelte
 <Keydown
   on:keydown={(e) => {
     if (e.key === " ") e.preventDefault();

--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ Set `pauseOnInput` to prevent the utility from capturing keydown events on input
 {evt.join("")}
 ```
 
+### Preventing the default behavior
+
+This component forward the `on:keyup` and `on:keydown` events.
+
+You can use `on:keydown` to prevent the default behavior for certain keys.
+
+In the following example, pressing "Space" should not cause the browser page to scroll.
+
+```svelte no-display
+<Keydown
+  on:keydown={(e) => {
+    if (e.key === " ") e.preventDefault();
+  }}
+  on:Space={(e) => {
+    console.log("key", "Space");
+  }}
+/>
+```
+
 ## Examples
 
 ### Escape to close a modal
@@ -126,6 +145,11 @@ Use the `combo` dispatched event to listen for a combination of keys.
 | :----------- | :-------- | :------------ |
 | paused       | `boolean` | `false`       |
 | pauseOnInput | `boolean` | `false`       |
+
+### Forwarded events
+
+- `on:keyup`
+- `on:keydown`
 
 ### Dispatched events
 

--- a/src/Keydown.svelte
+++ b/src/Keydown.svelte
@@ -1,9 +1,4 @@
 <script>
-  /**
-   * @event {string} combo
-   * @event {string} key
-   */
-
   /** Set to `true` to pause the capture of keydown events */
   export let paused = false;
 
@@ -23,11 +18,13 @@
 </script>
 
 <svelte:body
+  on:keyup
   on:keyup={({ key }) => {
     down = down.filter((_key) => _key !== key);
     if (down.length > 0) return;
     combo = [];
   }}
+  on:keydown
   on:keydown={({ key, target }) => {
     if (pauseOnInput && target.tagName !== "BODY") {
       return;

--- a/test/Keydown.test.svelte
+++ b/test/Keydown.test.svelte
@@ -9,7 +9,9 @@
 <Keydown
   pauseOnInput
   paused={!showModal}
-  on:Escape={() => (showModal = false)}
+  on:keyup={(e) => console.log(e)}
+  on:keydown={(e) => console.log(e)}
+  on:Escape={(e) => (showModal = false)}
   on:combo={(e) => {
     console.log(e.detail); // string
   }}

--- a/types/Keydown.svelte.d.ts
+++ b/types/Keydown.svelte.d.ts
@@ -20,6 +20,10 @@ export default class Keydown extends SvelteComponentTyped<
   {
     combo: CustomEvent<string>;
     key: CustomEvent<string>;
+    // @ts-expect-error
+    keyup: WindowEventMap["keyup"];
+    // @ts-expect-error
+    keydown: WindowEventMap["keydown"];
     [key: string]: CustomEvent<any>;
   },
   {}


### PR DESCRIPTION
Closes #11 

```svelte
<Keydown
  on:keydown={(e) => {
    if (e.key === " ") e.preventDefault();
  }}
  on:Space={(e) => {
    console.log("key", "Space");
  }}
/>
```