### PR TITLE
Added the ablity to choose tthe separator when using on:combo

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,29 @@ Use the `combo` dispatched event to listen for a combination of keys.
 {combo.join(", ")}
 ```
 
+#### `separator`
+
+Use the `separator` property to specify the string between key when using `on:combo`
+
+```svelte
+<script>
+  import Keydown from "svelte-keydown";
+
+  let combo = [];
+</script>
+
+<Keydown separator="+" on:combo={(e) => (combo = [...combo, e.detail])} />
+
+{combo.join(", ")}
+```
+
 ## API
 
 | Prop         | Type      | Default value |
 | :----------- | :-------- | :------------ |
 | paused       | `boolean` | `false`       |
 | pauseOnInput | `boolean` | `false`       |
+| separator    | `string`  | `-`           |
 
 ### Forwarded events
 
@@ -201,6 +218,31 @@ Examples:
 </script>
 
 <Keydown on:combo={({ detail }) => (combos = [...combos, detail])} />
+
+<pre>
+  {JSON.stringify(combos, null, 2)}
+</pre>
+```
+
+
+##### separator
+
+Changes separator keys
+
+Examples:
+
+- "Shift+S"
+- "Meta+c" (Copy)
+- "Meta+v" (Paste)
+
+```svelte
+<script>
+  import Keydown from "svelte-keydown";
+
+  let combos = [];
+</script>
+
+<Keydown  separator="+" on:combo={({ detail }) => (combos = [...combos, detail])} />
 
 <pre>
   {JSON.stringify(combos, null, 2)}

--- a/README.md
+++ b/README.md
@@ -224,31 +224,6 @@ Examples:
 </pre>
 ```
 
-
-##### separator
-
-Changes separator keys
-
-Examples:
-
-- "Shift+S"
-- "Meta+c" (Copy)
-- "Meta+v" (Paste)
-
-```svelte
-<script>
-  import Keydown from "svelte-keydown";
-
-  let combos = [];
-</script>
-
-<Keydown  separator="+" on:combo={({ detail }) => (combos = [...combos, detail])} />
-
-<pre>
-  {JSON.stringify(combos, null, 2)}
-</pre>
-```
-
 ## TypeScript
 
 Svelte version 3.31 or greater is required to use this component with TypeScript.

--- a/src/Keydown.svelte
+++ b/src/Keydown.svelte
@@ -5,6 +5,9 @@
   /** Set to `true` to pause keydown events when typing in an input field */
   export let pauseOnInput = false;
 
+  /**Determines the what goes between keys in a combo*/
+  export let separator = "-";
+
   import { createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
@@ -12,7 +15,7 @@
   let combo = [];
   let down = [];
 
-  $: combination = combo.join("-");
+  $: combination = combo.join(separator);
   $: comboByKey = combo.reduce((keys, key) => ({ ...keys, [key]: true }), {});
   $: if (combo.length > 0) dispatch("combo", combination);
 </script>

--- a/types/Keydown.svelte.d.ts
+++ b/types/Keydown.svelte.d.ts
@@ -13,6 +13,12 @@ export interface KeydownProps {
    * @default false
    */
   pauseOnInput?: boolean;
+
+  /**
+   * Determines the what goes between keys in a combo*
+   * @default "-"
+   */
+  separator?: string;
 }
 
 export default class Keydown extends SvelteComponentTyped<


### PR DESCRIPTION
I needed my combo to be separated  by a  `+` instead of a `-`  for my use case


# `on:combo`

Triggered when a sequence of keys are pressed and cleared when a keyup event is fired.

Examples:

- "Shift-S"
- "Meta-c" (Copy)
- "Meta-v" (Paste)

```svelte
<script>
  import Keydown from "svelte-keydown";

  let combos = [];
</script>

<Keydown on:combo={({ detail }) => (combos = [...combos, detail])} />

<pre>
  {JSON.stringify(combos, null, 2)}
</pre>
```


## separator

Changes separator keys

Examples:

- "Shift+S"
- "Meta+c" (Copy)
- "Meta+v" (Paste)

```svelte
<script>
  import Keydown from "svelte-keydown";

  let combos = [];
</script>

<Keydown  separator="+" on:combo={({ detail }) => (combos = [...combos, detail])} />

<pre>
  {JSON.stringify(combos, null, 2)}
</pre>
```