### PR TITLE
Fix Vite Svelte warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "svelte": "./src/index.js",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.js"
+    }
+  },
   "scripts": {
     "dev": "rollup -cw",
     "test": "svelte-check --workspace=test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-keydown",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "description": "Utility to listen for keyboard events",
   "author": "Eric Liu (https://github.com/metonym)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-keydown",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "license": "MIT",
   "description": "Utility to listen for keyboard events",
   "author": "Eric Liu (https://github.com/metonym)",
@@ -9,7 +9,13 @@
   "types": "./src/index.d.ts",
   "exports": {
     ".": {
-      "svelte": "./src/index.js"
+      "types": "./src/index.d.ts",
+      "svelte": "./src/index.js",
+      "default": "./src/index.js"
+    },
+    "./src/*.svelte": {
+      "types": "./src/*.svelte.d.ts",
+      "import": "./src/*.svelte"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-keydown",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "license": "MIT",
   "description": "Utility to listen for keyboard events",
   "author": "Eric Liu (https://github.com/metonym)",


### PR DESCRIPTION
Currently vite plugin svelte warns of the following.
`[vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.`

It provides this link for details to resolve https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition

I have added the svelte export as instructed